### PR TITLE
Import changes in Ubuntu bionic up to 5.9.5+dfsg-0ubuntu2.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.3) bionic; urgency=medium
+
+  * Backport upstream patch to fix nullptr dereference in HTTP handler
+    (LP: #1833536).
+
+ -- Dmitry Shachnev <mitya57@ubuntu.com>  Thu, 20 Jun 2019 13:59:52 +0300
+
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.2) bionic; urgency=medium
+
+  * Backport two upstream patches to support legacy X11 keymaps
+    (LP: #1831505).
+
+ -- Dmitry Shachnev <mitya57@ubuntu.com>  Sat, 08 Jun 2019 10:32:11 +0300
+
 qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.1) bionic-security; urgency=medium
 
   * SECURITY UPDATE: double-free or corruption via illegal XML document

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.5) bionic-security; urgency=medium
+
+  * SECURITY UPDATE: division-by-zero via malformed PPM image
+    - debian/patches/CVE-2018-19872.patch: add extra check to
+      src/gui/image/qppmhandler.cpp.
+    - CVE-2018-19872
+  * SECURITY UPDATE: QPluginLoader loads plugins from the CWD
+    - debian/patches/CVE-2020-0569.patch: do not load plugin from the $PWD
+      in src/corelib/plugin/qpluginloader.cpp.
+    - CVE-2020-0569
+
+ -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Fri, 07 Feb 2020 10:41:20 -0500
+
 qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.4) bionic; urgency=medium
 
   * Fix default paper size in the print dialog (LP: #1846821).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.1) bionic-security; urgency=medium
+
+  * SECURITY UPDATE: double-free or corruption via illegal XML document
+    - debian/patches/CVE-2018-15518.patch: fix possible heap corruption in
+      QXmlStream in src/corelib/xml/qxmlstream_p.h.
+    - CVE-2018-15518
+  * SECURITY UPDATE: NULL pointer dereference in QGifHandler
+    - debian/patches/CVE-2018-19870.patch: check for QImage allocation
+      failure in src/plugins/imageformats/gif/qgifhandler.cpp.
+    - CVE-2018-19870
+  * SECURITY UPDATE: buffer overflow in QBmpHandler
+    - debian/patches/CVE-2018-19873.patch: check for out of range image
+      size in src/gui/image/qbmphandler.cpp.
+    - CVE-2018-19873
+
+ -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Mon, 25 Mar 2019 11:03:42 -0400
+
 qtbase-opensource-src (5.9.5+dfsg-0ubuntu2) bionic; urgency=medium
 
   * Backport two upstream commits to fix duplex printing (LP: #1776173).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.4) bionic; urgency=medium
+
+  * Fix default paper size in the print dialog (LP: #1846821).
+
+ -- Dmitry Shachnev <mitya57@debian.org>  Thu, 31 Oct 2019 00:00:50 +0300
+
 qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.3) bionic; urgency=medium
 
   * Backport upstream patch to fix nullptr dereference in HTTP handler

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubuntu2) bionic; urgency=medium
+
+  * Backport two upstream commits to fix duplex printing (LP: #1776173).
+    Thanks to Robert Bredereck for the initial patch!
+
+ -- Dmitry Shachnev <mitya57@ubuntu.com>  Wed, 06 Feb 2019 10:47:55 +0300
+
 qtbase-opensource-src (5.9.5+dfsg-0ubports2+rebuild1) xenial; urgency=medium
 
   * Update Jenkinsfile as of ubports/build-tools@0af3831

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qtbase-opensource-src (5.9.5+dfsg-0ubports3) xenial; urgency=medium
+
+  * Import changes in Ubuntu bionic upto 5.9.5+dfsg-0ubuntu2.5
+    - This includes 2 security updates.
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Wed, 12 Feb 2020 22:56:44 +0700
+
 qtbase-opensource-src (5.9.5+dfsg-0ubuntu2.5) bionic-security; urgency=medium
 
   * SECURITY UPDATE: division-by-zero via malformed PPM image

--- a/debian/patches/CVE-2018-15518.patch
+++ b/debian/patches/CVE-2018-15518.patch
@@ -1,0 +1,30 @@
+Backport of:
+
+From 6256729a6da532079505edfe4c56a6ef29cd8ab8 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@qt.io>
+Date: Mon, 13 Aug 2018 15:29:16 +0200
+Subject: [PATCH] Fix possible heap corruption in QXmlStream
+
+The value of 'tos' at the check might already be on the last element,
+so triggering stack expansion on the second last element is too late.
+
+Change-Id: Ib3ab2662d4d27a71effe9e988b9e172923af2908
+Reviewed-by: Richard J. Moore <rich@kde.org>
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+---
+ src/corelib/serialization/qxmlstream_p.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: qtbase-opensource-src-5.9.5+dfsg/src/corelib/xml/qxmlstream_p.h
+===================================================================
+--- qtbase-opensource-src-5.9.5+dfsg.orig/src/corelib/xml/qxmlstream_p.h	2019-02-05 13:11:27.085486521 -0500
++++ qtbase-opensource-src-5.9.5+dfsg/src/corelib/xml/qxmlstream_p.h	2019-02-05 13:11:27.077486473 -0500
+@@ -1243,7 +1243,7 @@ bool QXmlStreamReaderPrivate::parse()
+             state_stack[tos] = 0;
+             return true;
+         } else if (act > 0) {
+-            if (++tos == stack_size-1)
++            if (++tos >= stack_size-1)
+                 reallocateStack();
+ 
+             Value &val = sym_stack[tos];

--- a/debian/patches/CVE-2018-19870.patch
+++ b/debian/patches/CVE-2018-19870.patch
@@ -1,0 +1,41 @@
+Backport of:
+
+From 2841e2b61e32f26900bde987d469c8b97ea31999 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Fri, 3 Aug 2018 13:25:15 +0200
+Subject: [PATCH] Check for QImage allocation failure in qgifhandler
+
+Since image files easily can be (or corrupt files claim to be) huge,
+it is worth checking for out of memory situations.
+
+Change-Id: I635a3ec6852288079fdec4e14cf7e776fe59e9e0
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+---
+ src/plugins/imageformats/gif/qgifhandler.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+Index: qtbase-opensource-src-5.9.5+dfsg/src/plugins/imageformats/gif/qgifhandler.cpp
+===================================================================
+--- qtbase-opensource-src-5.9.5+dfsg.orig/src/plugins/imageformats/gif/qgifhandler.cpp	2019-02-05 13:14:56.854631243 -0500
++++ qtbase-opensource-src-5.9.5+dfsg/src/plugins/imageformats/gif/qgifhandler.cpp	2019-02-05 13:16:17.099024035 -0500
+@@ -354,7 +354,8 @@ int QGIFFormat::decode(QImage *image, co
+                     (*image) = QImage(swidth, sheight, format);
+                     bpl = image->bytesPerLine();
+                     bits = image->bits();
+-                    memset(bits, 0, image->byteCount());
++                    if (bits)
++                        memset(bits, 0, image->byteCount());
+                 }
+ 
+                 // Check if the previous attempt to create the image failed. If it
+@@ -415,6 +416,10 @@ int QGIFFormat::decode(QImage *image, co
+                         backingstore = QImage(qMax(backingstore.width(), w),
+                                               qMax(backingstore.height(), h),
+                                               QImage::Format_RGB32);
++                        if (backingstore.isNull()) {
++                            state = Error;
++                            return -1;
++                        }
+                         memset(backingstore.bits(), 0, backingstore.byteCount());
+                     }
+                     const int dest_bpl = backingstore.bytesPerLine();

--- a/debian/patches/CVE-2018-19872.patch
+++ b/debian/patches/CVE-2018-19872.patch
@@ -1,0 +1,31 @@
+From b7321368924c4dbed81aa008d76ebfb1dffd7e60 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Thu, 2 Aug 2018 13:11:20 +0200
+Subject: Fix crash in qppmhandler for certain malformed image files
+
+The ppm format specifies that the maximum color value field must be
+less than 65536. The handler did not enforce this, leading to
+potentional overflow when the value was used in 16 bits context.
+
+Task-number: QTBUG-69449
+Change-Id: Iea7a7e0f8953ec1ea8571e215687d12a9d77e11c
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+(cherry picked from commit 8c4207dddf9b2af0767de2ef0a10652612d462a5)
+(cherry picked from commit 805dce07b9797f5f2770a9d2c58d6d381784ca25)
+---
+ src/gui/image/qppmhandler.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+(limited to 'src/gui/image/qppmhandler.cpp')
+
+--- a/src/gui/image/qppmhandler.cpp
++++ b/src/gui/image/qppmhandler.cpp
+@@ -115,7 +115,7 @@ static bool read_pbm_header(QIODevice *d
+     else
+         mcc = read_pbm_int(device);               // get max color component
+ 
+-    if (w <= 0 || w > 32767 || h <= 0 || h > 32767 || mcc <= 0)
++    if (w <= 0 || w > 32767 || h <= 0 || h > 32767 || mcc <= 0 || mcc > 0xffff)
+         return false;                                        // weird P.M image
+ 
+     return true;

--- a/debian/patches/CVE-2018-19873.patch
+++ b/debian/patches/CVE-2018-19873.patch
@@ -1,0 +1,30 @@
+From 621ab8ab59901cc3f9bd98be709929c9eac997a8 Mon Sep 17 00:00:00 2001
+From: Eirik Aavitsland <eirik.aavitsland@qt.io>
+Date: Tue, 4 Sep 2018 11:08:06 +0200
+Subject: [PATCH] bmp image handler: check for out of range image size
+
+Make the decoder fail early to avoid spending time and memory on
+attempting to decode a corrupt image file.
+
+Change-Id: I874e04f3b43122d73f8e58c7a5bcc4a741b68264
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+---
+ src/gui/image/qbmphandler.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/gui/image/qbmphandler.cpp b/src/gui/image/qbmphandler.cpp
+index 587f375ce7f..5dff4ab0ac3 100644
+--- a/src/gui/image/qbmphandler.cpp
++++ b/src/gui/image/qbmphandler.cpp
+@@ -188,6 +188,8 @@ static bool read_dib_infoheader(QDataStream &s, BMP_INFOHDR &bi)
+     if (!(comp == BMP_RGB || (nbits == 4 && comp == BMP_RLE4) ||
+         (nbits == 8 && comp == BMP_RLE8) || ((nbits == 16 || nbits == 32) && comp == BMP_BITFIELDS)))
+          return false;                                // weird compression type
++    if (bi.biWidth < 0 || quint64(bi.biWidth) * qAbs(bi.biHeight) > 16384 * 16384)
++        return false;
+ 
+     return true;
+ }
+-- 
+2.16.3
+

--- a/debian/patches/CVE-2020-0569.patch
+++ b/debian/patches/CVE-2020-0569.patch
@@ -1,0 +1,24 @@
+From bf131e8d2181b3404f5293546ed390999f760404 Mon Sep 17 00:00:00 2001
+From: Olivier Goffart <ogoffart@woboq.com>
+Date: Fri, 8 Nov 2019 11:30:40 +0100
+Subject: Do not load plugin from the $PWD
+
+I see no reason why this would make sense to look for plugins in the current
+directory. And when there are plugins there, it may actually be wrong
+
+Change-Id: I5f5aa168021fedddafce90effde0d5762cd0c4c5
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+---
+ src/corelib/plugin/qpluginloader.cpp | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/src/corelib/plugin/qpluginloader.cpp
++++ b/src/corelib/plugin/qpluginloader.cpp
+@@ -304,7 +304,6 @@ static QString locatePlugin(const QStrin
+         paths.append(fileName.left(slash)); // don't include the '/'
+     } else {
+         paths = QCoreApplication::libraryPaths();
+-        paths.prepend(QStringLiteral(".")); // search in current dir first
+     }
+ 
+     for (const QString &path : qAsConst(paths)) {

--- a/debian/patches/default_paper_size.patch
+++ b/debian/patches/default_paper_size.patch
@@ -1,0 +1,93 @@
+Description: QPageSetupWidget::setPrinter: Use printdevice default paper size
+Origin: upstream, https://code.qt.io/cgit/qt/qtbase.git/commit/?id=ff67dedaaff2dc68
+Last-Update: 2019-10-30
+
+--- a/src/printsupport/dialogs/qpagesetupdialog_unix.cpp
++++ b/src/printsupport/dialogs/qpagesetupdialog_unix.cpp
+@@ -210,7 +210,7 @@ void QUnixPageSetupDialogPrivate::init()
+     Q_Q(QPageSetupDialog);
+ 
+     widget = new QPageSetupWidget(q);
+-    widget->setPrinter(printer);
++    widget->setPrinter(printer, nullptr);
+ 
+     QDialogButtonBox *buttons = new QDialogButtonBox(QDialogButtonBox::Ok
+                                                      | QDialogButtonBox::Cancel,
+@@ -372,12 +372,16 @@ void QPageSetupWidget::initPageSizes()
+ 
+ // Set the dialog to use the given QPrinter
+ // Usually only called on first creation
+-void QPageSetupWidget::setPrinter(QPrinter *printer)
++void QPageSetupWidget::setPrinter(QPrinter *printer, QPrintDevice *printDevice)
+ {
+     m_printer = printer;
+ 
+     // Initialize the layout to the current QPrinter layout
+     m_pageLayout = m_printer->pageLayout();
++
++    if (printDevice)
++        m_pageLayout.setPageSize(printDevice->defaultPageSize());
++
+     // Assume if margins are Points then is by default, so set to locale default units
+     if (m_pageLayout.units() == QPageLayout::Point) {
+         if (QLocale().measurementSystem() == QLocale::MetricSystem)
+--- a/src/printsupport/dialogs/qpagesetupdialog_unix_p.h
++++ b/src/printsupport/dialogs/qpagesetupdialog_unix_p.h
+@@ -64,6 +64,7 @@ QT_REQUIRE_CONFIG(printdialog);
+ QT_BEGIN_NAMESPACE
+ 
+ class QPrinter;
++class QPrintDevice;
+ class QPagePreview;
+ 
+ class QPageSetupWidget : public QWidget {
+@@ -72,7 +73,7 @@ public:
+     explicit QPageSetupWidget(QWidget *parent = 0);
+     explicit QPageSetupWidget(QPrinter *printer, QWidget *parent = 0);
+ 
+-    void setPrinter(QPrinter *printer);
++    void setPrinter(QPrinter *printer, QPrintDevice *printDevice);
+     void selectPrinter(QPrinter::OutputFormat outputFormat, const QString &printerName);
+     void setupPrinter() const;
+ 
+--- a/src/printsupport/dialogs/qprintdialog_unix.cpp
++++ b/src/printsupport/dialogs/qprintdialog_unix.cpp
+@@ -130,7 +130,7 @@ public:
+     void selectPrinter(QPrinter::OutputFormat outputFormat, const QString &printerName);
+ 
+     /// copy printer properties to the widget
+-    void applyPrinterProperties(QPrinter *p);
++    void applyPrinterProperties(QPrinter *p, QPrintDevice *printDevice);
+     void setupPrinter() const;
+ 
+ private:
+@@ -269,9 +269,9 @@ QPrintPropertiesDialog::~QPrintPropertie
+ {
+ }
+ 
+-void QPrintPropertiesDialog::applyPrinterProperties(QPrinter *p)
++void QPrintPropertiesDialog::applyPrinterProperties(QPrinter *p, QPrintDevice *printDevice)
+ {
+-    widget.pageSetup->setPrinter(p);
++    widget.pageSetup->setPrinter(p, printDevice);
+ #if QT_CONFIG(cupsjobwidget)
+     m_jobOptions->setPrinter(p);
+ #endif
+@@ -867,7 +867,7 @@ void QUnixPrintWidgetPrivate::applyPrint
+     // PDF printer not added to the dialog yet, we'll handle those cases in QUnixPrintWidgetPrivate::updateWidget
+ 
+     if (propertiesDialog)
+-        propertiesDialog->applyPrinterProperties(printer);
++        propertiesDialog->applyPrinterProperties(printer, &m_currentPrintDevice);
+ }
+ 
+ #if QT_CONFIG(messagebox)
+@@ -932,7 +932,7 @@ void QUnixPrintWidgetPrivate::setupPrint
+     propertiesDialog->setResult(QDialog::Rejected);
+     propertiesDialogShown = false;
+ 
+-    propertiesDialog->applyPrinterProperties(q->printer());
++    propertiesDialog->applyPrinterProperties(q->printer(), &m_currentPrintDevice);
+ 
+     if (q->isOptionEnabled(QPrintDialog::PrintToFile)
+         && (widget.printers->currentIndex() == widget.printers->count() - 1)) {// PDF

--- a/debian/patches/http_nullptr_dereference.patch
+++ b/debian/patches/http_nullptr_dereference.patch
@@ -1,0 +1,23 @@
+Description: don't retry a ssl connection if encryption was never finished
+ As explained in the inline comment we don't actually have a
+ protocol handler until we're done encrypting when we use SSL, but we
+ would still retry the connection if an error occurred between
+ "connected" and "encrypted". This would then lead us to fail an assert
+ that checked if a protocol handler had been set.
+Origin: upstream, https://code.qt.io/cgit/qt/qtbase.git/commit/?id=e431a3ac027915db
+Last-Update: 2019-06-20
+
+--- a/src/network/access/qhttpnetworkconnectionchannel.cpp
++++ b/src/network/access/qhttpnetworkconnectionchannel.cpp
+@@ -884,7 +884,10 @@ void QHttpNetworkConnectionChannel::_q_e
+         } else if (state != QHttpNetworkConnectionChannel::IdleState && state != QHttpNetworkConnectionChannel::ReadingState) {
+             // Try to reconnect/resend before sending an error.
+             // While "Reading" the _q_disconnected() will handle this.
+-            if (reconnectAttempts-- > 0) {
++            // If we're using ssl then the protocolHandler is not initialized until
++            // "encrypted" has been emitted, since retrying requires the protocolHandler (asserted)
++            // we will not try if encryption is not done.
++            if (!pendingEncrypt && reconnectAttempts-- > 0) {
+                 resendCurrentRequest();
+                 return;
+             } else {

--- a/debian/patches/qprintdialog_duplex.diff
+++ b/debian/patches/qprintdialog_duplex.diff
@@ -1,0 +1,88 @@
+Description: Unix print dialog: Properly initialize duplex
+Origin: upstream, commits:
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=f6fd3f18d301cde3
+ https://code.qt.io/cgit/qt/qtbase.git/commit/?id=fa854f214a3c812e
+Last-Update: 2019-02-06
+
+--- a/src/printsupport/dialogs/qprintdialog_unix.cpp
++++ b/src/printsupport/dialogs/qprintdialog_unix.cpp
+@@ -225,6 +225,10 @@ public:
+     QDialogButtonBox *buttons;
+     QPushButton *collapseButton;
+     QPrinter::OutputFormat printerOutputFormat;
++private:
++    void setExplicitDuplexMode(QPrint::DuplexMode duplexMode);
++    // duplex mode explicitly set by user, QPrint::DuplexAuto otherwise
++    QPrint::DuplexMode explicitDuplexMode;
+ };
+ 
+ 
+@@ -298,7 +302,8 @@ void QPrintPropertiesDialog::selectPrint
+ 
+ */
+ QPrintDialogPrivate::QPrintDialogPrivate()
+-    : top(0), bottom(0), buttons(0), collapseButton(0)
++    : top(0), bottom(0), buttons(0), collapseButton(0),
++      explicitDuplexMode(QPrint::DuplexAuto)
+ {
+     initResources();
+ }
+@@ -357,6 +362,10 @@ void QPrintDialogPrivate::init()
+                      q, SLOT(_q_togglePageSetCombo(bool)));
+ 
+     QObject::connect(collapseButton, SIGNAL(released()), q, SLOT(_q_collapseOrExpandDialog()));
++
++    QObject::connect(options.noDuplex, &QAbstractButton::clicked, q, [this] { setExplicitDuplexMode(QPrint::DuplexNone); });
++    QObject::connect(options.duplexLong, &QAbstractButton::clicked, q, [this] { setExplicitDuplexMode(QPrint::DuplexLongSide); });
++    QObject::connect(options.duplexShort, &QAbstractButton::clicked, q, [this] { setExplicitDuplexMode(QPrint::DuplexShortSide); });
+ }
+ 
+ // initialize printer options
+@@ -366,18 +375,30 @@ void QPrintDialogPrivate::selectPrinter(
+         QPrinter *p = q->printer();
+         printerOutputFormat = outputFormat;
+ 
++        // printer supports duplex mode?
++        const auto supportedDuplexMode = top->d->m_currentPrintDevice.supportedDuplexModes();
++        options.duplexLong->setEnabled(supportedDuplexMode.contains(QPrint::DuplexLongSide));
++        options.duplexShort->setEnabled(supportedDuplexMode.contains(QPrint::DuplexShortSide));
++
+         if (p->colorMode() == QPrinter::Color)
+             options.color->setChecked(true);
+         else
+             options.grayscale->setChecked(true);
+ 
+-        switch (p->duplex()) {
+-        case QPrinter::DuplexNone:
++        // keep duplex value explicitly set by user, if any, and selected printer supports it;
++        // use device default otherwise
++        QPrint::DuplexMode duplex;
++        if (explicitDuplexMode != QPrint::DuplexAuto && supportedDuplexMode.contains(explicitDuplexMode))
++            duplex = explicitDuplexMode;
++        else
++            duplex = top->d->m_currentPrintDevice.defaultDuplexMode();
++        switch (duplex) {
++        case QPrint::DuplexNone:
+             options.noDuplex->setChecked(true); break;
+-        case QPrinter::DuplexLongSide:
+-        case QPrinter::DuplexAuto:
++        case QPrint::DuplexLongSide:
++        case QPrint::DuplexAuto:
+             options.duplexLong->setChecked(true); break;
+-        case QPrinter::DuplexShortSide:
++        case QPrint::DuplexShortSide:
+             options.duplexShort->setChecked(true); break;
+         }
+         options.copies->setValue(p->copyCount());
+@@ -398,6 +419,11 @@ void QPrintDialogPrivate::applyPrinterPr
+     top->d->applyPrinterProperties();
+ }
+ 
++void QPrintDialogPrivate::setExplicitDuplexMode(const QPrint::DuplexMode duplexMode)
++{
++    explicitDuplexMode = duplexMode;
++}
++
+ void QPrintDialogPrivate::setupPrinter()
+ {
+     // First setup the requested OutputFormat, Printer and Page Size first

--- a/debian/patches/refactor_updateModifiers.patch
+++ b/debian/patches/refactor_updateModifiers.patch
@@ -1,0 +1,171 @@
+Description: refactor QXcbKeyboard::updateModifiers()
+ The current implementation is poorly documented and hides the mapping
+ between keysyms and modifier bits.
+ .
+ This changeset adds documentation about the inner workings and makes
+ the keysym/modifier bit mapping reusable. (The latter will be needed for
+ xkb keymap synthesis if the XKEYBOARD extension is unavailable.)
+Origin: upstream, https://code.qt.io/cgit/qt/qtbase.git/commit/?id=f8b164e1c37ca901
+Last-Update: 2019-06-07
+
+--- a/src/plugins/platforms/xcb/qxcbkeyboard.cpp
++++ b/src/plugins/platforms/xcb/qxcbkeyboard.cpp
+@@ -1397,15 +1397,51 @@ void QXcbKeyboard::updateVModToRModMappi
+ #endif
+ }
+ 
++// Small helper: set modifier bit, if modifier position is valid
++static inline void applyModifier(uint *mask, int modifierBit)
++{
++    if (modifierBit >= 0 && modifierBit < 8)
++        *mask |= 1 << modifierBit;
++}
++
+ void QXcbKeyboard::updateModifiers()
+ {
++    memset(&rmod_masks, 0, sizeof(rmod_masks));
++
++    // Compute X modifier bits for Qt modifiers
++    KeysymModifierMap keysymMods(keysymsToModifiers());
++    applyModifier(&rmod_masks.alt,   keysymMods.value(XK_Alt_L,       -1));
++    applyModifier(&rmod_masks.alt,   keysymMods.value(XK_Alt_R,       -1));
++    applyModifier(&rmod_masks.meta,  keysymMods.value(XK_Meta_L,      -1));
++    applyModifier(&rmod_masks.meta,  keysymMods.value(XK_Meta_R,      -1));
++    applyModifier(&rmod_masks.altgr, keysymMods.value(XK_Mode_switch, -1));
++    applyModifier(&rmod_masks.super, keysymMods.value(XK_Super_L,     -1));
++    applyModifier(&rmod_masks.super, keysymMods.value(XK_Super_R,     -1));
++    applyModifier(&rmod_masks.hyper, keysymMods.value(XK_Hyper_L,     -1));
++    applyModifier(&rmod_masks.hyper, keysymMods.value(XK_Hyper_R,     -1));
++
++    resolveMaskConflicts();
++}
++
++// Small helper: check if an array of xcb_keycode_t contains a certain code
++static inline bool keycodes_contains(xcb_keycode_t *codes, xcb_keycode_t which)
++{
++    while (*codes != XCB_NO_SYMBOL) {
++        if (*codes == which) return true;
++        codes++;
++    }
++    return false;
++}
++
++QXcbKeyboard::KeysymModifierMap QXcbKeyboard::keysymsToModifiers()
++{
+     // The core protocol does not provide a convenient way to determine the mapping
+     // of modifier bits. Clients must retrieve and search the modifier map to determine
+     // the keycodes bound to each modifier, and then retrieve and search the keyboard
+     // mapping to determine the keysyms bound to the keycodes. They must repeat this
+     // process for all modifiers whenever any part of the modifier mapping is changed.
+-    memset(&rmod_masks, 0, sizeof(rmod_masks));
+ 
++    KeysymModifierMap map;
+     xcb_generic_error_t *error = 0;
+     xcb_connection_t *conn = xcb_connection();
+     xcb_get_modifier_mapping_cookie_t modMapCookie = xcb_get_modifier_mapping(conn);
+@@ -1414,7 +1450,7 @@ void QXcbKeyboard::updateModifiers()
+     if (error) {
+         qWarning("Qt: failed to get modifier mapping");
+         free(error);
+-        return;
++        return map;
+     }
+ 
+     // for Alt and Meta L and R are the same
+@@ -1430,27 +1466,54 @@ void QXcbKeyboard::updateModifiers()
+         modKeyCodes[i] = xcb_key_symbols_get_keycode(m_key_symbols, symbols[i]);
+ 
+     xcb_keycode_t *modMap = xcb_get_modifier_mapping_keycodes(modMapReply);
+-    const int w = modMapReply->keycodes_per_modifier;
+-    for (size_t i = 0; i < numSymbols; ++i) {
+-        for (int bit = 0; bit < 8; ++bit) {
+-            uint mask = 1 << bit;
+-            for (int x = 0; x < w; ++x) {
+-                xcb_keycode_t keyCode = modMap[x + bit * w];
+-                xcb_keycode_t *itk = modKeyCodes[i];
+-                while (itk && *itk != XCB_NO_SYMBOL)
+-                    if (*itk++ == keyCode) {
+-                        uint sym = symbols[i];
+-                        if ((sym == XK_Alt_L || sym == XK_Alt_R))
+-                            rmod_masks.alt = mask;
+-                        if ((sym == XK_Meta_L || sym == XK_Meta_R))
+-                            rmod_masks.meta = mask;
+-                        if (sym == XK_Mode_switch)
+-                            rmod_masks.altgr = mask;
+-                        if ((sym == XK_Super_L) || (sym == XK_Super_R))
+-                            rmod_masks.super = mask;
+-                        if ((sym == XK_Hyper_L) || (sym == XK_Hyper_R))
+-                            rmod_masks.hyper = mask;
+-                    }
++    const int modMapLength = xcb_get_modifier_mapping_keycodes_length(modMapReply);
++    /* For each modifier of "Shift, Lock, Control, Mod1, Mod2, Mod3,
++     * Mod4, and Mod5" the modifier map contains keycodes_per_modifier
++     * key codes that are associated with a modifier.
++     *
++     * As an example, take this 'xmodmap' output:
++     *   xmodmap: up to 4 keys per modifier, (keycodes in parentheses):
++     *
++     *   shift       Shift_L (0x32),  Shift_R (0x3e)
++     *   lock        Caps_Lock (0x42)
++     *   control     Control_L (0x25),  Control_R (0x69)
++     *   mod1        Alt_L (0x40),  Alt_R (0x6c),  Meta_L (0xcd)
++     *   mod2        Num_Lock (0x4d)
++     *   mod3
++     *   mod4        Super_L (0x85),  Super_R (0x86),  Super_L (0xce),  Hyper_L (0xcf)
++     *   mod5        ISO_Level3_Shift (0x5c),  Mode_switch (0xcb)
++     *
++     * The corresponding raw modifier map would contain keycodes for:
++     *   Shift_L (0x32), Shift_R (0x3e), 0, 0,
++     *   Caps_Lock (0x42), 0, 0, 0,
++     *   Control_L (0x25), Control_R (0x69), 0, 0,
++     *   Alt_L (0x40), Alt_R (0x6c), Meta_L (0xcd), 0,
++     *   Num_Lock (0x4d), 0, 0, 0,
++     *   0,0,0,0,
++     *   Super_L (0x85),  Super_R (0x86),  Super_L (0xce),  Hyper_L (0xcf),
++     *   ISO_Level3_Shift (0x5c),  Mode_switch (0xcb), 0, 0
++     */
++
++    /* Create a map between a modifier keysym (as per the symbols array)
++     * and the modifier bit it's associated with (if any).
++     * As modMap contains key codes, search modKeyCodes for a match;
++     * if one is found we can look up the associated keysym.
++     * Together with the modifier index this will be used
++     * to compute a mapping between X modifier bits and Qt's
++     * modifiers (Alt, Ctrl etc). */
++    for (int i = 0; i < modMapLength; i++) {
++        if (modMap[i] == XCB_NO_SYMBOL)
++            continue;
++        // Get key symbol for key code
++        for (size_t k = 0; k < numSymbols; k++) {
++            if (modKeyCodes[k] && keycodes_contains(modKeyCodes[k], modMap[i])) {
++                // Key code is for modifier. Record mapping
++                xcb_keysym_t sym = symbols[k];
++                /* As per modMap layout explanation above, dividing
++                 * by keycodes_per_modifier gives the 'row' in the
++                 * modifier map, which in turn is the modifier bit. */
++                map[sym] = i / modMapReply->keycodes_per_modifier;
++                break;
+             }
+         }
+     }
+@@ -1458,7 +1521,8 @@ void QXcbKeyboard::updateModifiers()
+     for (size_t i = 0; i < numSymbols; ++i)
+         free(modKeyCodes[i]);
+     free(modMapReply);
+-    resolveMaskConflicts();
++
++    return map;
+ }
+ 
+ void QXcbKeyboard::resolveMaskConflicts()
+--- a/src/plugins/platforms/xcb/qxcbkeyboard.h
++++ b/src/plugins/platforms/xcb/qxcbkeyboard.h
+@@ -96,6 +96,8 @@ protected:
+     void clearXKBConfig();
+     // when XKEYBOARD not present on the X server
+     void updateModifiers();
++    typedef QMap<xcb_keysym_t, int> KeysymModifierMap;
++    KeysymModifierMap keysymsToModifiers();
+     // when XKEYBOARD is present on the X server
+     void updateVModMapping();
+     void updateVModToRModMapping();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,6 +11,7 @@ CVE-2018-19873.patch
 refactor_updateModifiers.patch
 support_legacy_x11_keymaps.patch
 http_nullptr_dereference.patch
+default_paper_size.patch
 
 # Debian specific.
 gnukfreebsd.diff

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,6 +5,9 @@ dbustray_newmenu_signal.diff
 extend_mariadb_define_check.diff
 fix-loading-OpenGL-when-symlink-missing.patch
 qprintdialog_duplex.diff
+CVE-2018-15518.patch
+CVE-2018-19870.patch
+CVE-2018-19873.patch
 
 # Debian specific.
 gnukfreebsd.diff

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,6 +8,9 @@ qprintdialog_duplex.diff
 CVE-2018-15518.patch
 CVE-2018-19870.patch
 CVE-2018-19873.patch
+refactor_updateModifiers.patch
+support_legacy_x11_keymaps.patch
+http_nullptr_dereference.patch
 
 # Debian specific.
 gnukfreebsd.diff

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,6 +4,7 @@ dead_key_symbols.diff
 dbustray_newmenu_signal.diff
 extend_mariadb_define_check.diff
 fix-loading-OpenGL-when-symlink-missing.patch
+qprintdialog_duplex.diff
 
 # Debian specific.
 gnukfreebsd.diff

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,5 @@ nonlinux_utime.diff
 qt5-qmake-arm-linux-gnueabihf
 # Not yet forwarded.
 hidpi_scale_at_192.diff
+CVE-2018-19872.patch
+CVE-2020-0569.patch

--- a/debian/patches/support_legacy_x11_keymaps.patch
+++ b/debian/patches/support_legacy_x11_keymaps.patch
@@ -1,0 +1,395 @@
+Description: support legacy X11 keymaps
+ Not all X server vendors support the XKB protocol. Furthermore,
+ while X.org seems to use keycodes that match the usual keyboard
+ scancodes, other vendors may not do so. This means that using an
+ XKB keymap suitable for an X.org server results in garbled input
+ with servers for other vendors.
+ .
+ Both of these issues are addressed by using the core keycode
+ information as a fallback.
+Origin: upstream, https://code.qt.io/cgit/qt/qtbase.git/commit/?id=3edcd9420e3ad661
+Last-Update: 2019-06-07
+
+--- a/src/plugins/platforms/xcb/qxcbkeyboard.cpp
++++ b/src/plugins/platforms/xcb/qxcbkeyboard.cpp
+@@ -59,6 +59,10 @@
+ #undef KeyRelease
+ #endif
+ 
++#if QT_CONFIG(xcb_xlib)
++#include <X11/Xutil.h>
++#endif
++
+ #ifndef XK_ISO_Left_Tab
+ #define XK_ISO_Left_Tab         0xFE20
+ #endif
+@@ -776,9 +780,310 @@ void QXcbKeyboard::printKeymapError(cons
+              "directory contains recent enough contents, to update please see http://cgit.freedesktop.org/xkeyboard-config/ .");
+ }
+ 
++#if QT_CONFIG(xcb_xlib)
++/* Look at a pair of unshifted and shifted key symbols.
++ * If the 'unshifted' symbol is uppercase and there is no shifted symbol,
++ * return the matching lowercase symbol; otherwise return 0.
++ * The caller can then use the previously 'unshifted' symbol as the new
++ * 'shifted' (uppercase) symbol and the symbol returned by the function
++ * as the new 'unshifted' (lowercase) symbol.) */
++static xcb_keysym_t getUnshiftedXKey(xcb_keysym_t unshifted, xcb_keysym_t shifted)
++{
++    if (shifted != XKB_KEY_NoSymbol) // Has a shifted symbol
++        return 0;
++
++    KeySym xlower;
++    KeySym xupper;
++    /* libxkbcommon >= 0.8.0 will have public API functions providing
++     * functionality equivalent to XConvertCase(), use these once the
++     * minimal libxkbcommon version is high enough. After that the
++     * xcb-xlib dependency can be removed */
++    XConvertCase(static_cast<KeySym>(unshifted), &xlower, &xupper);
++
++    if (xlower != xupper                                     // Check if symbol is cased
++        && unshifted == static_cast<xcb_keysym_t>(xupper)) { // Unshifted must be upper case
++        return static_cast<xcb_keysym_t>(xlower);
++    }
++    return 0;
++}
++
++static QByteArray symbolsGroupString(const xcb_keysym_t *symbols, int count)
++{
++    // Don't output trailing NoSymbols
++    while (count > 0 && symbols[count - 1] == XKB_KEY_NoSymbol)
++        count--;
++
++    QByteArray groupString;
++    for (int symIndex = 0; symIndex < count; symIndex++) {
++        xcb_keysym_t sym = symbols[symIndex];
++        char symString[64];
++        if (sym == XKB_KEY_NoSymbol)
++            strcpy(symString, "NoSymbol");
++        else
++            xkb_keysym_get_name(sym, symString, sizeof(symString));
++
++        if (!groupString.isEmpty())
++            groupString += ", ";
++        groupString += symString;
++    }
++    return groupString;
++}
++
++struct xkb_keymap *QXcbKeyboard::keymapFromCore()
++{
++    /* Construct an XKB keymap string from information queried from
++     * the X server */
++    QByteArray keymap;
++    keymap += "xkb_keymap {\n";
++
++    const xcb_keycode_t minKeycode = connection()->setup()->min_keycode;
++    const xcb_keycode_t maxKeycode = connection()->setup()->max_keycode;
++
++    // Generate symbolic names from keycodes
++    {
++        keymap +=
++            "xkb_keycodes \"core\" {\n"
++            "\tminimum = " + QByteArray::number(minKeycode) + ";\n"
++            "\tmaximum = " + QByteArray::number(maxKeycode) + ";\n";
++        for (int code = minKeycode; code <= maxKeycode; code++) {
++            auto codeStr = QByteArray::number(code);
++            keymap += "<K" + codeStr + "> = " + codeStr + ";\n";
++        }
++        /* TODO: indicators?
++         */
++        keymap += "};\n"; // xkb_keycodes
++    }
++
++    /* Set up default types (xkbcommon automatically assigns these to
++     * symbols, but doesn't have shift info) */
++    keymap +=
++        "xkb_types \"core\" {\n"
++        "virtual_modifiers NumLock,Alt,LevelThree;\n"
++        "type \"ONE_LEVEL\" {\n"
++            "modifiers= none;\n"
++            "level_name[Level1] = \"Any\";\n"
++        "};\n"
++        "type \"TWO_LEVEL\" {\n"
++            "modifiers= Shift;\n"
++            "map[Shift]= Level2;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Shift\";\n"
++        "};\n"
++        "type \"ALPHABETIC\" {\n"
++            "modifiers= Shift+Lock;\n"
++            "map[Shift]= Level2;\n"
++            "map[Lock]= Level2;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Caps\";\n"
++        "};\n"
++        "type \"KEYPAD\" {\n"
++            "modifiers= Shift+NumLock;\n"
++            "map[Shift]= Level2;\n"
++            "map[NumLock]= Level2;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Number\";\n"
++        "};\n"
++        "type \"FOUR_LEVEL\" {\n"
++            "modifiers= Shift+LevelThree;\n"
++            "map[Shift]= Level2;\n"
++            "map[LevelThree]= Level3;\n"
++            "map[Shift+LevelThree]= Level4;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Shift\";\n"
++            "level_name[Level3] = \"Alt Base\";\n"
++            "level_name[Level4] = \"Shift Alt\";\n"
++        "};\n"
++        "type \"FOUR_LEVEL_ALPHABETIC\" {\n"
++            "modifiers= Shift+Lock+LevelThree;\n"
++            "map[Shift]= Level2;\n"
++            "map[Lock]= Level2;\n"
++            "map[LevelThree]= Level3;\n"
++            "map[Shift+LevelThree]= Level4;\n"
++            "map[Lock+LevelThree]= Level4;\n"
++            "map[Shift+Lock+LevelThree]= Level3;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Shift\";\n"
++            "level_name[Level3] = \"Alt Base\";\n"
++            "level_name[Level4] = \"Shift Alt\";\n"
++        "};\n"
++        "type \"FOUR_LEVEL_SEMIALPHABETIC\" {\n"
++            "modifiers= Shift+Lock+LevelThree;\n"
++            "map[Shift]= Level2;\n"
++            "map[Lock]= Level2;\n"
++            "map[LevelThree]= Level3;\n"
++            "map[Shift+LevelThree]= Level4;\n"
++            "map[Lock+LevelThree]= Level3;\n"
++            "preserve[Lock+LevelThree]= Lock;\n"
++            "map[Shift+Lock+LevelThree]= Level4;\n"
++            "preserve[Shift+Lock+LevelThree]= Lock;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Shift\";\n"
++            "level_name[Level3] = \"Alt Base\";\n"
++            "level_name[Level4] = \"Shift Alt\";\n"
++        "};\n"
++        "type \"FOUR_LEVEL_KEYPAD\" {\n"
++            "modifiers= Shift+NumLock+LevelThree;\n"
++            "map[Shift]= Level2;\n"
++            "map[NumLock]= Level2;\n"
++            "map[LevelThree]= Level3;\n"
++            "map[Shift+LevelThree]= Level4;\n"
++            "map[NumLock+LevelThree]= Level4;\n"
++            "map[Shift+NumLock+LevelThree]= Level3;\n"
++            "level_name[Level1] = \"Base\";\n"
++            "level_name[Level2] = \"Number\";\n"
++            "level_name[Level3] = \"Alt Base\";\n"
++            "level_name[Level4] = \"Alt Number\";\n"
++        "};\n"
++        "};\n"; // xkb_types
++
++    // Generate mapping between symbolic names and keysyms
++    {
++        QVector<xcb_keysym_t> xkeymap;
++        int keysymsPerKeycode = 0;
++        {
++            int keycodeCount = maxKeycode - minKeycode + 1;
++
++            xcb_get_keyboard_mapping_cookie_t keymapCookie;
++            xcb_get_keyboard_mapping_reply_t *keymapReply;
++            keymapCookie = xcb_get_keyboard_mapping(xcb_connection(), minKeycode, keycodeCount);
++            keymapReply = xcb_get_keyboard_mapping_reply(xcb_connection(), keymapCookie, NULL);
++            if (keymapReply) {
++                keysymsPerKeycode = keymapReply->keysyms_per_keycode;
++                int numSyms = keycodeCount * keysymsPerKeycode;
++                auto keymapPtr = xcb_get_keyboard_mapping_keysyms(keymapReply);
++                xkeymap.resize(numSyms);
++                for (int i = 0; i < numSyms; i++)
++                    xkeymap[i] = keymapPtr[i];
++                free(keymapReply);
++            } else {
++                qWarning("Qt: failed to retrieve the keyboard mapping from XKB");
++            }
++        }
++        if (xkeymap.isEmpty())
++            return nullptr;
++
++        KeysymModifierMap keysymMods(keysymsToModifiers());
++        static const char *const builtinModifiers[] =
++        { "Shift", "Lock", "Control", "Mod1", "Mod2", "Mod3", "Mod4", "Mod5" };
++
++        /* Level 3 symbols (e.g. AltGr+something) seem to come in two flavors:
++         * - as a proper level 3 in group 1, at least on recent X.org versions
++         * - 'disguised' as group 2, on 'legacy' X servers
++         * In the 2nd case, remap group 2 to level 3, that seems to work better
++         * in practice */
++        bool mapGroup2ToLevel3 = keysymsPerKeycode < 5;
++
++        keymap += "xkb_symbols \"core\" {\n";
++        for (int code = minKeycode; code <= maxKeycode; code++) {
++            auto codeMap = xkeymap.constData() + (code - minKeycode) * keysymsPerKeycode;
++
++            const int maxGroup1 = 4; // We only support 4 shift states anyway
++            const int maxGroup2 = 2; // Only 3rd and 4th keysym are group 2
++            xcb_keysym_t symbolsGroup1[maxGroup1];
++            xcb_keysym_t symbolsGroup2[maxGroup2];
++            for (int i = 0; i < maxGroup1 + maxGroup2; i++) {
++                xcb_keysym_t sym = i < keysymsPerKeycode ? codeMap[i] : XKB_KEY_NoSymbol;
++                if (mapGroup2ToLevel3) {
++                    // Merge into single group
++                    if (i < maxGroup1)
++                        symbolsGroup1[i] = sym;
++                } else {
++                    // Preserve groups
++                    if (i < 2)
++                        symbolsGroup1[i] = sym;
++                    else if (i < 4)
++                        symbolsGroup2[i - 2] = sym;
++                    else
++                        symbolsGroup1[i - 2] = sym;
++                }
++            }
++
++            /* Fix symbols so the unshifted and shifted symbols have
++             * lower resp. upper case */
++            if (auto lowered = getUnshiftedXKey(symbolsGroup1[0], symbolsGroup1[1])) {
++                symbolsGroup1[1] = symbolsGroup1[0];
++                symbolsGroup1[0] = lowered;
++            }
++            if (auto lowered = getUnshiftedXKey(symbolsGroup2[0], symbolsGroup2[1])) {
++                symbolsGroup2[1] = symbolsGroup2[0];
++                symbolsGroup2[0] = lowered;
++            }
++
++            QByteArray groupStr1 = symbolsGroupString(symbolsGroup1, maxGroup1);
++            if (groupStr1.isEmpty())
++                continue;
++
++            keymap += "key <K" + QByteArray::number(code) + "> { ";
++            keymap += "symbols[Group1] = [ " + groupStr1 + " ]";
++            QByteArray groupStr2 = symbolsGroupString(symbolsGroup2, maxGroup2);
++            if (!groupStr2.isEmpty())
++                keymap += ", symbols[Group2] = [ " + groupStr2 + " ]";
++
++            // See if this key code is for a modifier
++            xcb_keysym_t modifierSym = XKB_KEY_NoSymbol;
++            for (int symIndex = 0; symIndex < keysymsPerKeycode; symIndex++) {
++                xcb_keysym_t sym = codeMap[symIndex];
++
++                if (sym == XKB_KEY_Alt_L
++                    || sym == XKB_KEY_Meta_L
++                    || sym == XKB_KEY_Mode_switch
++                    || sym == XKB_KEY_Super_L
++                    || sym == XKB_KEY_Super_R
++                    || sym == XKB_KEY_Hyper_L
++                    || sym == XKB_KEY_Hyper_R) {
++                    modifierSym = sym;
++                    break;
++                }
++            }
++
++            // AltGr
++            if (modifierSym == XKB_KEY_Mode_switch)
++                keymap += ", virtualMods=LevelThree";
++            keymap += " };\n"; // key
++
++            // Generate modifier mappings
++            int modNum = keysymMods.value(modifierSym, -1);
++            if (modNum != -1) {
++                // Here modNum is always < 8 (see keysymsToModifiers())
++                keymap += QByteArray("modifier_map ") + builtinModifiers[modNum]
++                    + " { <K" + QByteArray::number(code) + "> };\n";
++            }
++        }
++        // TODO: indicators?
++        keymap += "};\n"; // xkb_symbols
++    }
++
++    // We need an "Alt" modifier, provide via the xkb_compatibility section
++    keymap +=
++        "xkb_compatibility \"core\" {\n"
++        "virtual_modifiers NumLock,Alt,LevelThree;\n"
++        "interpret Alt_L+AnyOf(all) {\n"
++            "virtualModifier= Alt;\n"
++            "action= SetMods(modifiers=modMapMods,clearLocks);\n"
++        "};\n"
++        "interpret Alt_R+AnyOf(all) {\n"
++            "virtualModifier= Alt;\n"
++            "action= SetMods(modifiers=modMapMods,clearLocks);\n"
++        "};\n"
++        "};\n";
++
++    /* TODO: There is an issue with modifier state not being handled
++     * correctly if using Xming with XKEYBOARD disabled. */
++
++    keymap += "};\n"; // xkb_keymap
++
++    return xkb_keymap_new_from_buffer(xkb_context,
++                                      keymap.constData(),
++                                      keymap.size(),
++                                      XKB_KEYMAP_FORMAT_TEXT_V1,
++                                      static_cast<xkb_keymap_compile_flags>(0));
++}
++#endif
++
+ void QXcbKeyboard::updateKeymap()
+ {
+     m_config = true;
++    m_keymap_is_core = false;
+     // set xkb context object
+     if (!xkb_context) {
+         if (qEnvironmentVariableIsSet("QT_XKB_CONFIG_ROOT")) {
+@@ -812,9 +1117,23 @@ void QXcbKeyboard::updateKeymap()
+     }
+ #endif
+     if (!xkb_keymap) {
+-        // Compile a keymap from RMLVO (rules, models, layouts, variants and options) names
++        // Read xkb RMLVO (rules, models, layouts, variants and options) names
+         readXKBConfig();
+-        xkb_keymap = xkb_keymap_new_from_names(xkb_context, &xkb_names, (xkb_keymap_compile_flags)0);
++#if QT_CONFIG(xcb_xlib)
++        bool rmlvo_is_incomplete = !xkb_names.rules || !(*xkb_names.rules)
++            || !xkb_names.model || !(*xkb_names.model)
++            || !xkb_names.layout || !(*xkb_names.layout);
++        if (rmlvo_is_incomplete) {
++            // Try to build xkb map from core mapping information
++            xkb_keymap = keymapFromCore();
++            m_keymap_is_core = xkb_keymap != 0;
++        }
++#endif
++        if (!xkb_keymap) {
++            // Compile a keymap from RMLVO
++            xkb_keymap = xkb_keymap_new_from_names(xkb_context, &xkb_names,
++                static_cast<xkb_keymap_compile_flags> (0));
++        }
+         if (!xkb_keymap) {
+             // last fallback is to used hard-coded keymap name, see DEFAULT_XKB_* in xkbcommon.pri
+             qWarning() << "Qt: Could not determine keyboard configuration data"
+@@ -1006,9 +1325,11 @@ xkb_keysym_t QXcbKeyboard::lookupLatinKe
+     // If user layouts don't contain any layout that results in a latin key, we query a
+     // key from "US" layout, this allows for latin-key-based shorcuts to work even when
+     // users have only one (non-latin) layout set.
++    // But don't do this if using keymap obtained through the core protocol, as the key
++    // codes may not match up with those expected by the XKB keymap.
+     xkb_mod_mask_t latchedMods = xkb_state_serialize_mods(xkb_state, XKB_STATE_MODS_LATCHED);
+     xkb_mod_mask_t lockedMods = xkb_state_serialize_mods(xkb_state, XKB_STATE_MODS_LOCKED);
+-    if (sym == XKB_KEY_NoSymbol && !m_hasLatinLayout) {
++    if (sym == XKB_KEY_NoSymbol && !m_hasLatinLayout && !m_keymap_is_core) {
+         if (!latin_keymap) {
+             const struct xkb_rule_names names = { xkb_names.rules, xkb_names.model, "us", 0, 0 };
+             latin_keymap = xkb_keymap_new_from_names(xkb_context, &names, (xkb_keymap_compile_flags)0);
+--- a/src/plugins/platforms/xcb/qxcbkeyboard.h
++++ b/src/plugins/platforms/xcb/qxcbkeyboard.h
+@@ -94,6 +94,9 @@ protected:
+ 
+     void readXKBConfig();
+     void clearXKBConfig();
++#if QT_CONFIG(xcb_xlib)
++    struct xkb_keymap *keymapFromCore();
++#endif
+     // when XKEYBOARD not present on the X server
+     void updateModifiers();
+     typedef QMap<xcb_keysym_t, int> KeysymModifierMap;
+@@ -109,6 +112,7 @@ private:
+     void updateXKBStateFromState(struct xkb_state *kb_state, quint16 state);
+ 
+     bool m_config = false;
++    bool m_keymap_is_core = false;
+     xcb_keycode_t m_autorepeat_code = 0;
+ 
+     struct xkb_context *xkb_context = nullptr;


### PR DESCRIPTION
This PR brings updates for the Qt base package to UBports, including 2 security updates fixing 5 vulnerabilities.

I would like this to be in OTA-12. The regression potential is quite minimum.
- Our version contains only a single additional patch.
- All but the last version has been in Ubuntu bionic for a while.
- The last version is a security update.

Thus, they should be safe to include in OTA-12.

This supersedes #12 using a branch in UBports repo for easy installation with `ubports-qa`.